### PR TITLE
Fixed videos opening in full screen by default on iOS

### DIFF
--- a/packages/youtube_player_iframe/lib/src/players/youtube_player_mobile.dart
+++ b/packages/youtube_player_iframe/lib/src/players/youtube_player_mobile.dart
@@ -134,7 +134,8 @@ class _MobileYoutubePlayerState extends State<RawYoutubePlayer>
         if (feature == 'emb_rel_pause') {
           controller.load(uri.queryParameters['v']);
         } else {
-          url_launcher.launch(detail.url);
+          //url_launcher.launch(detail.url);
+          return ShouldOverrideUrlLoadingAction.ALLOW;
         }
         return ShouldOverrideUrlLoadingAction.CANCEL;
       },


### PR DESCRIPTION
Fixed videos opening in full screen by default on iOS